### PR TITLE
Add pydantic==1.10.9 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 accelerate==0.18.0
 datasets==2.10.0
 deepspeed==0.8.3
+pydantic==1.10.9
 evaluate==0.3.0
 fire==0.5.0
 hydra-core==1.2.0


### PR DESCRIPTION
To address the issue raised in Issue #16 regarding the inability to run the demo due to an error, this pull request updates the requirements.txt file to include pydantic==1.10.9.

**Changes:**
Added pydantic==1.10.9 to requirements.txt.

**Reason:** 
Please look at Issue #16.

**Testing:**
After adding pydantic to the requirements, I successfully ran the demo without encountering the error.